### PR TITLE
Refactor API package and unify schemas

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,0 +1,1 @@
+"""Doc_GPT API package."""

--- a/api/init.py
+++ b/api/init.py
@@ -1,2 +1,0 @@
-# D:\projects\Doc_GPT\api\__init__.py
-# (empty)

--- a/api/main.py
+++ b/api/main.py
@@ -9,7 +9,6 @@ from typing import List, Optional, Dict, Any, Tuple
 import numpy as np
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
-from pydantic import BaseModel, Field
 from sklearn.neighbors import NearestNeighbors
 from rank_bm25 import BM25Okapi
 from sentence_transformers import SentenceTransformer
@@ -53,37 +52,7 @@ SHOW_RETRIEVED = True
 # --------------------------------------------------------------------------------------
 # Data Models
 # --------------------------------------------------------------------------------------
-class AskRequest(BaseModel):
-    query: str = Field(..., description="User question/symptoms")
-    k: int = Field(6, ge=1, le=20, description="Number of chunks to include")
-
-
-class Citation(BaseModel):
-    n: str
-    title: str
-    url: str
-    score: str
-
-
-class RetrievedItem(BaseModel):
-    text: str
-    meta: Dict[str, Any]
-    score: float
-    rerank_score: Optional[float] = None
-    rerank_kind: Optional[str] = None
-
-
-class RedFlag(BaseModel):
-    severity: str
-    matches: List[str] = Field(default_factory=list)
-    banner: str = ""
-
-
-class AskResponse(BaseModel):
-    answer: str
-    citations: List[Citation]
-    red_flag: RedFlag
-    retrieved: Optional[List[RetrievedItem]] = None
+from .schemas import AskRequest, AskResponse, Citation, RetrievedItem, RedFlag
 
 
 # --------------------------------------------------------------------------------------

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -1,55 +1,81 @@
 # D:\projects\Doc_GPT\api\schemas.py
 from __future__ import annotations
-from typing import List, Optional, Literal
+from typing import Any, Dict, List, Optional, Literal
 from pydantic import BaseModel, Field
 
+# ---------------------------------------------------------------------------
+# Core RAG API schemas
+# ---------------------------------------------------------------------------
+
 Gender = Literal["male", "female", "other", "unknown"]
+
 
 class UserProfile(BaseModel):
     gender: Gender = "unknown"
     age: int = Field(ge=0, le=120)
+
 
 class Vitals(BaseModel):
     temperature_c: Optional[float] = Field(default=None, ge=30, le=45)
     heart_rate: Optional[int] = Field(default=None, ge=30, le=220)
     spo2: Optional[int] = Field(default=None, ge=50, le=100)
 
+
 class AskRequest(BaseModel):
-    query: str
-    k: int = 6
+    query: str = Field(..., description="User question/symptoms")
+    k: int = Field(6, ge=1, le=20, description="Number of chunks to include")
+
 
 class Citation(BaseModel):
-    n: int
+    n: str
     title: str
     url: str
+    score: str
+
+
+class RetrievedItem(BaseModel):
+    text: str
+    meta: Dict[str, Any]
     score: float
+    rerank_score: Optional[float] = None
+    rerank_kind: Optional[str] = None
+
 
 class RedFlag(BaseModel):
     severity: Literal["none", "consider", "urgent", "emergency"] = "none"
-    matches: List[str] = []
+    matches: List[str] = Field(default_factory=list)
     banner: str = ""
+
 
 class AskResponse(BaseModel):
     answer: str
-    citations: List[Citation] = []
-    red_flag: RedFlag = RedFlag()
+    citations: List[Citation] = Field(default_factory=list)
+    red_flag: RedFlag = Field(default_factory=RedFlag)
+    retrieved: Optional[List[RetrievedItem]] = None
+
+
+# ---------------------------------------------------------------------------
+# Intake / triage helper schemas
+# ---------------------------------------------------------------------------
 
 class IntakeQuery(BaseModel):
     profile: UserProfile
-    symptoms: List[str] = []
+    symptoms: List[str] = Field(default_factory=list)
     free_text: str = ""
     vitals: Optional[Vitals] = None
     k: int = 6
+
 
 class ConditionCandidate(BaseModel):
     name: str
     confidence: float
 
+
 class IntakeResponse(BaseModel):
-    condition_candidates: List[ConditionCandidate] = []
-    first_aid: List[str] = []
-    otc: List[str] = []
-    follow_ups: List[str] = []
+    condition_candidates: List[ConditionCandidate] = Field(default_factory=list)
+    first_aid: List[str] = Field(default_factory=list)
+    otc: List[str] = Field(default_factory=list)
+    follow_ups: List[str] = Field(default_factory=list)
     answer: str
-    citations: List[Citation] = []
-    red_flag: RedFlag = RedFlag()
+    citations: List[Citation] = Field(default_factory=list)
+    red_flag: RedFlag = Field(default_factory=RedFlag)

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,4 @@ rank-bm25==0.2.2
 tqdm==4.66.5
 tenacity==9.0.0
 jinja2==3.1.4
+openai==1.52.0


### PR DESCRIPTION
## Summary
- rename api package so FastAPI modules import cleanly
- consolidate Pydantic schemas with safe defaults for lists
- declare OpenAI client dependency for local LLM usage

## Testing
- `python -m pytest`
- `curl -sS http://127.0.0.1:8000/healthz` *(fails: Flat index dir not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5e8caa84c8326aab5336328e6e29e