### PR TITLE
feat: load env file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# Example environment configuration for Doc_GPT
+OPENAI_BASE_URL=http://127.0.0.1:1234/v1
+OPENAI_API_KEY=not-needed-for-local
+LLM_MODEL=meta-llama-3.1-8b-instruct
+EMBEDDING_MODEL=sentence-transformers/all-MiniLM-L6-v2
+COLLECTION_NAME=doc_gpt
+CHROMA_DIR=./data/chroma
+FLAT_INDEX_DIR=./data/flatindex
+HYBRID_ALPHA=0.4
+RERANK_MODEL=cross-encoder/ms-marco-MiniLM-L-6-v2
+RERANK_TOP_M=12

--- a/api/main.py
+++ b/api/main.py
@@ -13,6 +13,7 @@ from sklearn.neighbors import NearestNeighbors
 from rank_bm25 import BM25Okapi
 from sentence_transformers import SentenceTransformer
 from tenacity import retry, wait_exponential, stop_after_attempt
+from dotenv import load_dotenv
 
 # OpenAI-compatible client (for LM Studio or OpenAI)
 try:
@@ -22,6 +23,9 @@ except Exception:  # fallback if older SDK is present
 
 # Local utils
 from utils.red_flags import detect_red_flags, classify_red_flag_severity, RED_FLAG_BANNER
+
+# Load environment variables from a local .env file if present
+load_dotenv()
 
 
 # --------------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- load `.env` file automatically when starting API
- add `.env.example` with sample configuration

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c5f897e5288326840b4f2096ebbff9