### PR TITLE
fix: serve web ui and clarify setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# Example environment configuration for Doc_GPT
+OPENAI_BASE_URL=http://127.0.0.1:1234/v1
+OPENAI_API_KEY=not-needed-for-local
+LLM_MODEL=meta-llama-3.1-8b-instruct
+EMBEDDING_MODEL=sentence-transformers/all-MiniLM-L6-v2
+COLLECTION_NAME=doc_gpt
+CHROMA_DIR=./data/chroma
+FLAT_INDEX_DIR=./data/flatindex
+HYBRID_ALPHA=0.4
+RERANK_MODEL=cross-encoder/ms-marco-MiniLM-L-6-v2
+RERANK_TOP_M=12

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-@'
 # --- Python / venv ---
 .venv/
 __pycache__/
@@ -35,4 +34,3 @@ lmstudio-*.*
 node_modules/
 dist/
 build/
-'@ | Set-Content -Encoding UTF8 .gitignore

--- a/README.md
+++ b/README.md
@@ -52,17 +52,28 @@ py -3.12 -m venv .venv
 pip install --upgrade pip
 pip install -r requirements.txt
 
-3. Environment variables (.env file at project root)
-# LLM connection
+3. Configure environment variables
+Copy `.env.example` to `.env` and tweak values if you need different ports or models:
+
+cp .env.example .env
+
+Defaults:
 OPENAI_BASE_URL=http://127.0.0.1:1234/v1
 OPENAI_API_KEY=not-needed-for-local
 LLM_MODEL=meta-llama-3.1-8b-instruct
-
-# Indexing
 EMBEDDING_MODEL=sentence-transformers/all-MiniLM-L6-v2
 COLLECTION_NAME=doc_gpt
 CHROMA_DIR=./data/chroma
+FLAT_INDEX_DIR=./data/flatindex
+HYBRID_ALPHA=0.4
+RERANK_MODEL=cross-encoder/ms-marco-MiniLM-L-6-v2
+RERANK_TOP_M=12
 
+4. Start a local LLM server (LM Studio)
+- Launch LM Studio and open **Developer / Server**.
+- Pick a chat-friendly model, e.g. `Meta-Llama-3.1-8B-Instruct`.
+- Set the port to `1234` so it matches `OPENAI_BASE_URL`.
+- Click **Start Server**. LM Studio now serves an OpenAI-compatible endpoint at `http://127.0.0.1:1234/v1`.
 🕸️ Crawl Data
 
 Edit data/sources.csv with NHS/CDC links like:
@@ -94,7 +105,7 @@ python -m uvicorn api.main:app --host 127.0.0.1 --port 8000
 
 Then open in browser:
 
-http://127.0.0.1:8000/web/index.html
+http://127.0.0.1:8000/  (redirects to the bundled web UI)
 
 💬 Example Query
 Invoke-RestMethod -Uri "http://127.0.0.1:8000/ask" -Method POST `

--- a/api/config.py
+++ b/api/config.py
@@ -1,0 +1,66 @@
+"""Runtime configuration helpers for the Doc_GPT API."""
+from __future__ import annotations
+
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Iterable
+
+from pydantic import Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+ROOT = Path(__file__).resolve().parents[1]
+ENV_FILES: tuple[Path, ...] = (ROOT / ".env", ROOT / ".env.local")
+
+
+def _resolve_path(base: Path, value: Path) -> Path:
+    """Return an absolute path, interpreting relative values from the project root."""
+    if value.is_absolute():
+        return value
+    return (base / value).resolve()
+
+
+class Settings(BaseSettings):
+    """Application configuration loaded from environment variables and `.env` files."""
+
+    model_config = SettingsConfigDict(
+        env_file=[str(path) for path in ENV_FILES],
+        env_file_encoding="utf-8",
+        extra="ignore",
+        case_sensitive=False,
+    )
+
+    flat_index_dir: Path = Field(default=ROOT / "data" / "flatindex", alias="FLAT_INDEX_DIR")
+    web_dir: Path = Field(default=ROOT / "web", alias="WEB_DIR")
+    embedding_model: str = Field(
+        default="sentence-transformers/all-MiniLM-L6-v2", alias="EMBEDDING_MODEL"
+    )
+    hybrid_alpha: float = Field(default=0.40, alias="HYBRID_ALPHA")
+    rerank_model: str = Field(
+        default="cross-encoder/ms-marco-MiniLM-L-6-v2", alias="RERANK_MODEL"
+    )
+    rerank_top_m: int = Field(default=12, alias="RERANK_TOP_M")
+    openai_base_url: str = Field(default="http://127.0.0.1:1234/v1", alias="OPENAI_BASE_URL")
+    openai_api_key: str = Field(default="lm-studio", alias="OPENAI_API_KEY")
+    llm_model: str = Field(default="meta-llama-3.1-8b-instruct", alias="LLM_MODEL")
+    show_retrieved: bool = Field(default=True, alias="SHOW_RETRIEVED")
+
+    def model_post_init(self, __context: Any) -> None:  # pragma: no cover - trivial post processing
+        # Resolve any relative paths against the project root so downstream code can rely on
+        # canonical locations regardless of the working directory used to launch the app.
+        self.flat_index_dir = _resolve_path(ROOT, self.flat_index_dir)
+        self.web_dir = _resolve_path(ROOT, self.web_dir)
+
+
+@lru_cache(maxsize=1)
+def get_settings() -> Settings:
+    """Return a cached ``Settings`` instance so configuration is parsed only once."""
+
+    return Settings()
+
+
+def iter_existing_env_files() -> Iterable[Path]:
+    """Yield `.env`-style files that are present on disk."""
+
+    for path in ENV_FILES:
+        if path.exists():
+            yield path

--- a/api/main.py
+++ b/api/main.py
@@ -9,10 +9,15 @@ from typing import List, Optional, Dict, Any, Tuple
 import numpy as np
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import RedirectResponse
+from fastapi.staticfiles import StaticFiles
 from sklearn.neighbors import NearestNeighbors
 from rank_bm25 import BM25Okapi
 from sentence_transformers import SentenceTransformer
 from tenacity import retry, wait_exponential, stop_after_attempt
+from dotenv import load_dotenv
+
+ROOT = Path(__file__).resolve().parents[1]
 
 # OpenAI-compatible client (for LM Studio or OpenAI)
 try:
@@ -23,12 +28,16 @@ except Exception:  # fallback if older SDK is present
 # Local utils
 from utils.red_flags import detect_red_flags, classify_red_flag_severity, RED_FLAG_BANNER
 
+# Load environment variables from repo-local .env files if present
+load_dotenv(ROOT / ".env", override=False)
+load_dotenv(ROOT / ".env.local", override=False)
+
 
 # --------------------------------------------------------------------------------------
 # Settings
 # --------------------------------------------------------------------------------------
-ROOT = Path(__file__).resolve().parents[1]
 FLAT_DIR = Path(os.getenv("FLAT_INDEX_DIR") or ROOT / "data" / "flatindex")
+WEB_DIR = ROOT / "web"
 EMB_MODEL_NAME = os.getenv("EMBEDDING_MODEL", "sentence-transformers/all-MiniLM-L6-v2")
 
 # Hybrid (dense + BM25) controls
@@ -295,6 +304,9 @@ class RAGEngine:
 # --------------------------------------------------------------------------------------
 app = FastAPI(title="Doc_GPT API", version="0.1.0")
 
+if WEB_DIR.exists():
+    app.mount("/web", StaticFiles(directory=str(WEB_DIR), html=True), name="web")
+
 # CORS: allow local UI/dev ports
 app.add_middleware(
     CORSMiddleware,
@@ -308,6 +320,13 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+# Redirect root to the web UI when available
+@app.get("/", include_in_schema=False)
+def serve_root() -> Any:
+    if WEB_DIR.exists():
+        return RedirectResponse(url="/web/index.html")
+    return {"status": "ok"}
 
 # Initialize engine at import time
 try:

--- a/api/main.py
+++ b/api/main.py
@@ -2,9 +2,8 @@
 from __future__ import annotations
 
 import json
-import os
 from pathlib import Path
-from typing import List, Optional, Dict, Any, Tuple
+from typing import List, Dict, Any, Tuple
 
 import numpy as np
 from fastapi import FastAPI, HTTPException
@@ -15,9 +14,6 @@ from sklearn.neighbors import NearestNeighbors
 from rank_bm25 import BM25Okapi
 from sentence_transformers import SentenceTransformer
 from tenacity import retry, wait_exponential, stop_after_attempt
-from dotenv import load_dotenv
-
-ROOT = Path(__file__).resolve().parents[1]
 
 # OpenAI-compatible client (for LM Studio or OpenAI)
 try:
@@ -27,35 +23,35 @@ except Exception:  # fallback if older SDK is present
 
 # Local utils
 from utils.red_flags import detect_red_flags, classify_red_flag_severity, RED_FLAG_BANNER
+from .config import get_settings, iter_existing_env_files
 
-# Load environment variables from repo-local .env files if present
-load_dotenv(ROOT / ".env", override=False)
-load_dotenv(ROOT / ".env.local", override=False)
+settings = get_settings()
+ENV_FILES_LOADED = tuple(str(path) for path in iter_existing_env_files())
 
 
 # --------------------------------------------------------------------------------------
 # Settings
 # --------------------------------------------------------------------------------------
-FLAT_DIR = Path(os.getenv("FLAT_INDEX_DIR") or ROOT / "data" / "flatindex")
-WEB_DIR = ROOT / "web"
-EMB_MODEL_NAME = os.getenv("EMBEDDING_MODEL", "sentence-transformers/all-MiniLM-L6-v2")
+FLAT_DIR = settings.flat_index_dir
+WEB_DIR = settings.web_dir
+EMB_MODEL_NAME = settings.embedding_model
 
 # Hybrid (dense + BM25) controls
 HYBRID = True
-ALPHA = float(os.getenv("HYBRID_ALPHA", "0.40"))  # weight for dense side in [0,1]
+ALPHA = max(0.0, min(1.0, settings.hybrid_alpha))  # weight for dense side in [0,1]
 
 # Reranker (optional)
 RERANK = True
-RERANK_MODEL = os.getenv("RERANK_MODEL", "cross-encoder/ms-marco-MiniLM-L-6-v2")
-RERANK_TOP_M = int(os.getenv("RERANK_TOP_M", "12"))
+RERANK_MODEL = settings.rerank_model
+RERANK_TOP_M = settings.rerank_top_m
 
 # LLM (LM Studio or OpenAI-compatible)
-OPENAI_BASE_URL = os.getenv("OPENAI_BASE_URL", "http://127.0.0.1:1234/v1")
-OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", "lm-studio")  # any non-empty string for LM Studio
-LLM_MODEL = os.getenv("LLM_MODEL", "meta-llama-3.1-8b-instruct")
+OPENAI_BASE_URL = settings.openai_base_url
+OPENAI_API_KEY = settings.openai_api_key  # any non-empty string for LM Studio
+LLM_MODEL = settings.llm_model
 
 # Misc
-SHOW_RETRIEVED = True
+SHOW_RETRIEVED = settings.show_retrieved
 
 
 # --------------------------------------------------------------------------------------
@@ -340,12 +336,22 @@ else:
 
 @app.get("/healthz")
 def healthz() -> Dict[str, Any]:
+    env_info = {
+        "env_files": list(ENV_FILES_LOADED),
+        "web_dir": str(WEB_DIR),
+        "web_available": WEB_DIR.exists(),
+    }
+
     if ENGINE is None:
         return {
             "status": "error",
             "detail": str(INIT_ERR) if INIT_ERR else "unknown",
+            **env_info,
         }
-    return ENGINE.status()
+
+    payload = ENGINE.status()
+    payload.update(env_info)
+    return payload
 
 
 @app.post("/ask", response_model=AskResponse)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ pydantic==2.9.2
 pydantic-settings==2.5.2
 orjson==3.10.7
 httpx==0.27.2
+aiofiles==23.2.1
 
 beautifulsoup4==4.12.3
 lxml==5.3.0


### PR DESCRIPTION
## Summary
- load environment variables from the repo root and mount the bundled `web/` UI, including a `/` redirect
- document copying `.env.example`, starting the LM Studio server, and the updated UI URL in the README
- clean up the `.gitignore` markers and add `aiofiles` so FastAPI can serve static files

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c5f897e5288326840b4f2096ebbff9